### PR TITLE
Add signup link to attributes

### DIFF
--- a/custom_components/drkblutspende/sensor.py
+++ b/custom_components/drkblutspende/sensor.py
@@ -166,6 +166,7 @@ class DRKBlutspendeSensor(Entity):
                 self._state_attributes = data
                 self._state_attributes["address"] = description["address"]
                 self._state_attributes["location"] = description["location"]
+                self._state_attributes["link"] = entry["link"]
                 break
             else:
                 _LOGGER.debug(
@@ -179,6 +180,7 @@ class DRKBlutspendeSensor(Entity):
                     self._state_attributes = data
                     self._state_attributes["address"] = description["address"]
                     self._state_attributes["location"] = description["location"]
+                    self._state_attributes["link"] = entry["link"]
                     break
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)


### PR DESCRIPTION
This PR adds a new attribute with the signup link for the blood donation event:

![image](https://user-images.githubusercontent.com/948965/161981383-0113dadc-4db5-46a3-818f-6632660a97ea.png)

Can be used with the [custom button card](https://github.com/custom-cards/button-card) for example like so:

```
entity: sensor.blutspende
icon: mdi:blood-bag
icon_height: 64px
label: |
  [[[
     var date = states['sensor.blutspende'].attributes.date || '';
     var start = states['sensor.blutspende'].attributes.start || '';
     var end = states['sensor.blutspende'].attributes.end || '';
     var location = states['sensor.blutspende'].attributes.location || '';
     var city = states['sensor.blutspende'].attributes.city || '';
     var rv = "";
     if(date != '') {
       rv += 'am ' + date + '<br>';
     }
     if(location != '') {
       rv += location + '<br>';
     }
     if(city != '') {
       rv += city + '<br>';
     }
     if(start != '' && end != '') {
       rv += 'von ' + start + ' bis ' + end;
     }
     if(rv != '') {
       return rv;
     } else {
       return "Keine in den nächsten 2 Wochen"
     }
     
  ]]]
name: Blutspende
show_icon: true
show_label: true
show_name: true
styles:
  card:
    - height: 160px
  icon:
    - color: rgb(224, 53, 53)
  label:
    - font-size: 12px
  state:
    - font-size: 12px
tap_action:
  action: url
  url_path: '[[[ var link = states["sensor.blutspende"].attributes.link; return link ]]]'
type: custom:button-card

```

Looks like this and is clickable to open the link:

![image](https://user-images.githubusercontent.com/948965/161982185-e78dd488-4ec2-4a6c-af88-cf69425f46fe.png)
